### PR TITLE
fix: accessibility issue in side bar

### DIFF
--- a/packages/bruno-app/src/components/Notifications/index.js
+++ b/packages/bruno-app/src/components/Notifications/index.js
@@ -91,8 +91,10 @@ const Notifications = () => {
           dispatch(fetchNotifications());
           setShowNotificationsModal(true);
         }}
+        aria-label="check all Notifications"
       >
         <IconBell
+          aria-hidden
           size={18}
           strokeWidth={1.5}
           className={`mr-2 hover:text-gray-700 ${unreadNotifications?.length > 0 ? 'bell' : ''}`}

--- a/packages/bruno-app/src/components/Sidebar/TitleBar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/TitleBar/index.js
@@ -70,16 +70,12 @@ const TitleBar = () => {
       ) : null}
 
       <div className="flex items-center">
-        <div className="flex items-center cursor-pointer" onClick={handleTitleClick}>
-          <Bruno width={30} />
-        </div>
-        <div
-          onClick={handleTitleClick}
-          className="flex items-center font-medium select-none cursor-pointer"
-          style={{ fontSize: 14, paddingLeft: 6, position: 'relative', top: -1 }}
-        >
+        <button className="flex items-center gap-2 text-sm font-medium" onClick={handleTitleClick}>
+          <span aria-hidden>
+            <Bruno width={30} />
+          </span>
           bruno
-        </div>
+        </button>
         <div className="collection-dropdown flex flex-grow items-center justify-end">
           <Dropdown onCreate={onMenuDropdownCreate} icon={<MenuIcon />} placement="bottom-start">
             <div

--- a/packages/bruno-app/src/components/Sidebar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/index.js
@@ -81,7 +81,7 @@ const Sidebar = () => {
 
   return (
     <StyledWrapper className="flex relative h-screen">
-      <aside>
+      <nav>
         {goldenEditonOpen && <GoldenEdition onClose={() => setGoldenEditonOpen(false)} />}
         <div className="flex flex-row h-screen w-full">
           {preferencesOpen && <Preferences onClose={() => dispatch(showPreferences(false))} />}
@@ -94,30 +94,26 @@ const Sidebar = () => {
             </div>
 
             <div className="footer flex px-1 py-2 absolute bottom-0 left-0 right-0 items-center select-none">
-              <div className="flex items-center ml-1 text-xs ">
-                <a
-                  title="Preferences"
-                  className="mr-2 cursor-pointer hover:text-gray-700"
-                  onClick={() => dispatch(showPreferences(true))}
-                >
-                  <IconSettings size={18} strokeWidth={1.5} />
-                </a>
-                <a
-                  title="Cookies"
-                  className="mr-2 cursor-pointer hover:text-gray-700"
-                  onClick={() => setCookiesOpen(true)}
-                >
-                  <IconCookie size={18} strokeWidth={1.5} />
-                </a>
-                <a
-                  title="Golden Edition"
-                  className="mr-2 cursor-pointer hover:text-gray-700"
-                  onClick={() => setGoldenEditonOpen(true)}
-                >
-                  <IconHeart size={18} strokeWidth={1.5} />
-                </a>
-                <Notifications />
-              </div>
+              <ul role="menubar" className="flex items-center ml-1 text-xs ">
+                <li role="menuitem" className="mr-2 cursor-pointer hover:text-gray-700">
+                  <a title="Preferences" aria-label="Goto settings" onClick={() => dispatch(showPreferences(true))}>
+                    <IconSettings aria-hidden size={18} strokeWidth={1.5} />
+                  </a>
+                </li>
+                <li role="menuitem" className="mr-2 cursor-pointer hover:text-gray-700">
+                  <a title="Cookies" aria-label="see cookies saved" onClick={() => setCookiesOpen(true)}>
+                    <IconCookie aria-hidden size={18} strokeWidth={1.5} />
+                  </a>
+                </li>
+                <li role="menuitem" className="mr-2 cursor-pointer hover:text-gray-700">
+                  <a title="Golden Edition" aria-label="Get Golden Edition" onClick={() => setGoldenEditonOpen(true)}>
+                    <IconHeart aria-hidden size={18} strokeWidth={1.5} />
+                  </a>
+                </li>
+                <li role="menuitem">
+                  <Notifications />
+                </li>
+              </ul>
               <div className="pl-1" style={{ position: 'relative', top: '3px' }}>
                 {/* This will get moved to home page */}
                 {/* <GitHubButton
@@ -133,7 +129,7 @@ const Sidebar = () => {
             </div>
           </div>
         </div>
-      </aside>
+      </nav>
       <div className="absolute drag-sidebar h-full" onMouseDown={handleDragbarMouseDown}>
         <div className="drag-request-border" />
       </div>


### PR DESCRIPTION
# Description

### Fix accessibility issue in side nav bar footer icons
 - Make all svgs hidden to assistive technology 
 - Use proper tags to list menus: These are groups / are lists of items and provide menus for users to navigate. Hence should be descendent of `<ul> and <li>` tags
 - fix title accessibility issue, by wrapping bruno icon and text inside a single button rather than a 2 different buttons. Here bruno logo acts as decorative. Bruno logo and text together act as brand name here, they are not separate. Hence clubbed. 
 
 **Accessibility tree structure** 
 | then | now|
 | --|--|
 |<img width="1348" alt="Screenshot 2024-03-31 at 7 57 39 PM" src="https://github.com/usebruno/bruno/assets/29778698/db12e36e-ce11-4099-a5b1-377fe59e9848">|<img width="1349" alt="Screenshot 2024-03-31 at 7 57 09 PM" src="https://github.com/usebruno/bruno/assets/29778698/62ff4508-8cf0-4027-8fa2-e78da841d861"> |



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

